### PR TITLE
Feature/opponent profile: 멤버의 프로필 확인 페이지 구현

### DIFF
--- a/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
@@ -26,11 +26,14 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
+
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
+
 import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -77,7 +80,7 @@ public class MemberController {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/phoneAuth")
     @ResponseBody
-    public ResponseEntity phoneAuthComplete(String phoneNumber){
+    public ResponseEntity phoneAuthComplete(String phoneNumber) {
         Member member = rq.getMember();
         RsData<?> result = memberService.phoneAuthComplete(member, phoneNumber);
         if (result.isFail()) {
@@ -93,7 +96,7 @@ public class MemberController {
     public ResponseEntity phoneAuth(String phoneNumber) throws UnsupportedEncodingException, NoSuchAlgorithmException, InvalidKeyException {
         //핸드폰 번호를 가지고 있는 사용자가 존재하는지 체크
         boolean existPhoneNumber = memberService.existsPhoneNumber(phoneNumber);
-        if(existPhoneNumber){
+        if (existPhoneNumber) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("전화번호 중복");
         }
 
@@ -101,7 +104,7 @@ public class MemberController {
         String authCode = phoneAuthService.sendSms(phoneNumber);
 
         Member member = rq.getMember();
-        if(member != null){
+        if (member != null) {
             memberService.updateTmpPhone(member, phoneNumber);
         }
 
@@ -144,7 +147,7 @@ public class MemberController {
 
         //이미지 경로 세팅
         Optional<ProfileImage> profileImage = memberService.findProfileImage(member);
-        if(profileImage.isPresent())
+        if (profileImage.isPresent())
             profileRequestDto.setImagePath(profileImage.get().getFullPath());
         else
             profileRequestDto.setImagePath(null);
@@ -170,8 +173,8 @@ public class MemberController {
     @PostMapping("/profile_edit")
     @ResponseBody
     public ResponseEntity updateProfile(@ModelAttribute @Valid ProfileRequestDto profileRequestDto,
-                                BindingResult result,
-                                MultipartFile file) throws IOException {
+                                        BindingResult result,
+                                        MultipartFile file) throws IOException {
         //입력필드 검증
         Map<String, String> errors = new HashMap<>();
         if (result.hasErrors()) {
@@ -191,7 +194,7 @@ public class MemberController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/charge")
-    public String chargePoint(Model model){
+    public String chargePoint(Model model) {
         Member member = memberService.getMember();
         model.addAttribute("member", member);
         return "usr/member/charge";
@@ -204,6 +207,21 @@ public class MemberController {
         model.addAttribute("code", code);
         return "usr/member/fail";
 
+    }
+
+
+    @GetMapping("/profile/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public String opponentProfile(@PathVariable Long id, Model model) {
+        Member member = memberService.findById(id).orElse(null);
+
+        if (member == null) {
+            rq.historyBack("존재하는 회원이 없습니다.");
+        }
+
+        model.addAttribute("member", member);
+
+        return "usr/member/usrCheck";
     }
 
 }

--- a/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.ant.hurry.boundedContext.member.entity.Member;
 import com.ant.hurry.boundedContext.member.entity.ProfileImage;
 import com.ant.hurry.boundedContext.member.service.MemberService;
 import com.ant.hurry.boundedContext.member.service.PhoneAuthService;
+import com.ant.hurry.boundedContext.review.service.ReviewService;
 import com.ant.hurry.boundedContext.tradeStatus.service.TradeStatusService;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
 import jakarta.validation.Valid;
@@ -53,6 +54,7 @@ public class MemberController {
     private final MemberService memberService;
     private final PhoneAuthService phoneAuthService;
     private final TradeStatusService tradeStatusService;
+    private final ReviewService reviewService;
     private final Rq rq;
 
     @PreAuthorize("isAnonymous()")
@@ -225,9 +227,11 @@ public class MemberController {
         }
 
         Long completeTradeCount = tradeStatusService.getMemberComleteTradeStatusCount(id);
+        Long reviewCount = reviewService.getMemberReviewCount(id);
 
         model.addAttribute("member", rsData.getData());
         model.addAttribute("completeTradeCount", completeTradeCount);
+        model.addAttribute("reviewCount", reviewCount);
 
         return "usr/member/usrCheck";
     }

--- a/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
@@ -218,7 +218,7 @@ public class MemberController {
 
     @GetMapping("/profile/{id}")
     @PreAuthorize("isAuthenticated()")
-    public String opponentProfile(@PathVariable Long id, Model model) {
+    public String showProfile(@PathVariable Long id, Model model) {
 
         RsData<Member> rsData = memberService.validateAndReturnMember(id);
 
@@ -226,8 +226,8 @@ public class MemberController {
             return rq.historyBack(rsData.getMsg());
         }
 
-        Long completeTradeCount = tradeStatusService.getMemberComleteTradeStatusCount(id);
-        Long reviewCount = reviewService.getMemberReviewCount(id);
+        Long completeTradeCount = tradeStatusService.getComleteTradeStatusCount(id);
+        Long reviewCount = reviewService.getReviewCount(id);
 
         model.addAttribute("member", rsData.getData());
         model.addAttribute("completeTradeCount", completeTradeCount);

--- a/src/main/java/com/ant/hurry/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/service/MemberService.java
@@ -180,4 +180,16 @@ public class MemberService {
     public Optional<Member> findByNickname(String nickname) {
         return memberRepository.findByNickname(nickname);
     }
+
+    public RsData<Member> validateAndReturnMember(Long id) {
+
+        Member currentMember = getMember(); //접속한 유저
+        Member profileMember = findById(id).orElse(null); //프로필 유저
+
+        if (currentMember == null || profileMember == null) {
+            return RsData.of("F_M-2", "접근할 수 있는 권한이 없습니다.");
+        }
+
+        return RsData.successOf(profileMember);
+    }
 }

--- a/src/main/java/com/ant/hurry/boundedContext/review/controller/ReviewController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/review/controller/ReviewController.java
@@ -17,6 +17,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -61,18 +62,17 @@ public class ReviewController {
         return rq.redirectWithMsg("/review/list", reviewRsData);
     }
 
-    @GetMapping("/list")
+    @GetMapping("/list/{memberId}")
     @PreAuthorize("isAuthenticated()")
-    public String list(Model model, @AuthenticationPrincipal User user) {
+    public String list(Model model, @AuthenticationPrincipal User user, @PathVariable Long memberId) {
 
-        RsData<List<Review>> rsData = reviewService.getMyReviews(user.getUsername());
+        RsData<Map<String, Object>> rsData = reviewService.getReviews(user.getUsername(), memberId);
 
         if (rsData.isFail()) {
             return rq.historyBack(rsData.getMsg());
         }
 
-
-        model.addAttribute("reviews", rsData.getData());
+        model.addAttribute("reviewData", rsData.getData());
 
         return "review/list";
     }

--- a/src/main/java/com/ant/hurry/boundedContext/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ant/hurry/boundedContext/review/repository/ReviewRepository.java
@@ -15,4 +15,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByWriterAndTradeStatus(Member writer, TradeStatus tradeStatus);
 
     List<Review> findByReceiver(Member receiver);
+
+    Long countByReceiver_Id(Long receiverId);
 }

--- a/src/main/java/com/ant/hurry/boundedContext/review/service/ReviewService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/review/service/ReviewService.java
@@ -120,4 +120,8 @@ public class ReviewService {
         return RsData.of("S_R-3", "후기목록페이지로 이동합니다.", myReviews);
     }
 
+    public Long getMemberReviewCount(Long id) {
+        return reviewRepository.countByReceiver_Id(id);
+    }
+
 }

--- a/src/main/java/com/ant/hurry/boundedContext/review/service/ReviewService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/review/service/ReviewService.java
@@ -12,7 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -107,17 +109,22 @@ public class ReviewService {
         return RsData.of("S_R-2", "후기등록페이지로 이동합니다.", tradeStatus.getRequester().getNickname());
     }
 
-    public RsData<List<Review>> getMyReviews(String username) {
+    public RsData<Map<String, Object>> getReviews(String username, Long memberId) {
 
-        Member member = memberService.findByUsername(username).orElse(null);
+        Member currentMember = memberService.findByUsername(username).orElse(null);
+        Member profileMember = memberService.findById(memberId).orElse(null);
 
-        if (member == null) {
+        if (currentMember == null || profileMember == null) {
             return RsData.of("F_M-1", "존재하지 않는 회원입니다.");
         }
 
-        List<Review> myReviews = reviewRepository.findByReceiver(member);
+        Map<String, Object> map = new HashMap<>();
 
-        return RsData.of("S_R-3", "후기목록페이지로 이동합니다.", myReviews);
+        List<Review> reviews = reviewRepository.findByReceiver(profileMember);
+        map.put("reviews", reviews);
+        map.put("profileMember", profileMember);
+
+        return RsData.of("S_R-3", "후기목록페이지로 이동합니다.", map);
     }
 
     public Long getMemberReviewCount(Long id) {

--- a/src/main/java/com/ant/hurry/boundedContext/review/service/ReviewService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/review/service/ReviewService.java
@@ -127,7 +127,7 @@ public class ReviewService {
         return RsData.of("S_R-3", "후기목록페이지로 이동합니다.", map);
     }
 
-    public Long getMemberReviewCount(Long id) {
+    public Long getReviewCount(Long id) {
         return reviewRepository.countByReceiver_Id(id);
     }
 

--- a/src/main/java/com/ant/hurry/boundedContext/tradeStatus/repository/TradeStatusRepository.java
+++ b/src/main/java/com/ant/hurry/boundedContext/tradeStatus/repository/TradeStatusRepository.java
@@ -21,5 +21,10 @@ public interface TradeStatusRepository extends JpaRepository<TradeStatus, Long> 
             "and t.status = :status order by t.id desc")
     List<TradeStatus> findMyTradeStatus(@Param("memberId") Long memberId, @Param("status") Status status);
 
+    @Query("select count(t.id) from TradeStatus t inner join t.requester r inner join t.helper h " +
+            "where (r.id = :memberId or h.id = :memberId)" +
+            "and t.status = com.ant.hurry.boundedContext.tradeStatus.entity.Status.COMPLETE")
+    Long countMemberCompleteTradeStatus(@Param("memberId") Long memberId);
+
 
 }

--- a/src/main/java/com/ant/hurry/boundedContext/tradeStatus/service/TradeStatusService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/tradeStatus/service/TradeStatusService.java
@@ -89,7 +89,7 @@ public class TradeStatusService {
         return RsData.of(REDIRECT_TO_PAGE, tradeStatusList);
     }
 
-    public Long getMemberComleteTradeStatusCount(Long id) {
+    public Long getComleteTradeStatusCount(Long id) {
         return tradeStatusRepository.countMemberCompleteTradeStatus(id);
 
     }

--- a/src/main/java/com/ant/hurry/boundedContext/tradeStatus/service/TradeStatusService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/tradeStatus/service/TradeStatusService.java
@@ -88,4 +88,9 @@ public class TradeStatusService {
 
         return RsData.of(REDIRECT_TO_PAGE, tradeStatusList);
     }
+
+    public Long getMemberComleteTradeStatusCount(Long id) {
+        return tradeStatusRepository.countMemberCompleteTradeStatus(id);
+
+    }
 }

--- a/src/main/resources/templates/review/list.html
+++ b/src/main/resources/templates/review/list.html
@@ -25,6 +25,13 @@
 </header>
 
 <main layout:fragment="main">
+
+    <div class="flex-grow flex items-center justify-center">
+        <div th:if="${#lists.isEmpty(reviewData.get('reviews'))}" class="m-auto text-lg text-gray-400 pt-12">
+            후기가 존재하지 않습니다.<i class="fa-regular fa-face-sad-tear ml-2"></i>
+        </div>
+    </div>
+
     <div th:each="review : ${reviewData.get('reviews')}" class="max-w-md mt-3 mx-auto py-6 space-y-4 bg-white rounded-lg overflow-hidden shadow">
         <div class="px-4 py-3 ">
             <div class="flex items-center justify-between space-x-4">

--- a/src/main/resources/templates/review/list.html
+++ b/src/main/resources/templates/review/list.html
@@ -14,7 +14,7 @@
       </div>
     </div>
     <div class="navbar-center">
-      <a class="font-black">받은 거래 후기</a>
+      <a class="font-black" th:text="|${reviewData.get('profileMember').nickname}님의 받은 후기|"></a>
     </div>
     <div class="navbar-end">
       <button class="btn btn-ghost btn-circle hidden">
@@ -25,8 +25,8 @@
 </header>
 
 <main layout:fragment="main">
-    <div th:each="review : ${reviews}" class="max-w-md mx-auto py-6 space-y-4 bg-white rounded-lg overflow-hidden shadow">
-        <div class="px-4 py-3 border-b border-gray-200">
+    <div th:each="review : ${reviewData.get('reviews')}" class="max-w-md mt-3 mx-auto py-6 space-y-4 bg-white rounded-lg overflow-hidden shadow">
+        <div class="px-4 py-3 ">
             <div class="flex items-center justify-between space-x-4">
                 <div class="flex items-center space-x-4">
                     <div class="flex-shrink-0">

--- a/src/main/resources/templates/usr/member/profile.html
+++ b/src/main/resources/templates/usr/member/profile.html
@@ -55,7 +55,7 @@
                 <div class="divider divider-horizontal"></div>
                 <div class=" flex flex-col items-center  ">
                     <span class="text-lg text-white font-bold dark:text-gray-500">5</span>
-                    <span class="text-base text-white font-medium">리뷰</span>
+                    <span class="text-base text-white font-medium">후기</span>
                 </div>
                 <div class="divider divider-horizontal"></div>
                 <div class=" flex flex-col items-center pr-2 ">

--- a/src/main/resources/templates/usr/member/usrCheck.html
+++ b/src/main/resources/templates/usr/member/usrCheck.html
@@ -1,6 +1,7 @@
 <html layout:decorate="~{usr/layout/layout.html}" xmlns:layout="http://www.w3.org/1999/xhtml">
 
 <head>
+    <link rel="stylesheet" href="/resource/common/star.css">
     <title>상대방의 프로필</title>
 </head>
 
@@ -16,7 +17,7 @@
             </div>
         </div>
         <div class="navbar-center">
-            <a class="font-black">상대 프로필</a>
+            <a class="font-black" th:text="|${member.nickname}님의 프로필|"></a>
         </div>
         <div class="navbar-end">
             <button class="btn btn-ghost btn-circle">
@@ -28,7 +29,7 @@
 </header>
 
 <main layout:fragment="main" class="flex-grow flex items-center justify-center">
-    <section class="pt-16 bg-blue-50 md:w-[584px] w-[92%] mx-auto">
+    <section class="pt-16 md:w-[584px] w-[92%] mx-auto" style="background-color: #FFE4E1">
         <div class=" px-4 md:w-[400px] w-[92%] mx-auto">
             <div class="flex flex-col min-w-0 break-words bg-white w-full mb-6 shadow-xl rounded-lg mt-16 relative">
                 <div class="px-6">
@@ -39,38 +40,35 @@
                                      class="bg-pink-300 shadow-xl rounded-full align-middle -mt-16 h-40 z-50">
                             </div>
                         </div>
+                        <div class="text-center mt-4">
+                            <h3 class="text-xl font-semibold leading-normal mb-2 text-blueGray-700 mb-2" th:text="${member.nickname}">
+                            </h3>
+                            <div class="text-sm leading-normal mt-0 mb-2 text-blueGray-400 font-bold uppercase">
+                                <i class="fas fa-star text-yellow-400 mr-2" id="starElement"></i>
+                                <h5 th:text="${member.rating}"></h5>
+                            </div>
+                            <script th:inline="javascript">
+                                var starElement = document.getElementById('starElement');
+                                starElement.setAttribute('data-star', /*[[${member.rating}]]*/ null);
+                            </script>
+                            <div class="text-sm leading-normal mt-0 mb-2 text-blueGray-400 font-bold uppercase">
+                                <i class="fas fa-map-marker-alt mr-2 text-lg text-blueGray-400"></i>
+                                주 활동지?
+                            </div>
+                        </div>
                         <div class="w-full px-4 text-center">
                             <div class="flex justify-center py-4 lg:pt-4 pt-8">
                                 <div class="mr-4 p-3 text-center">
-                                    <span class="text-xl font-bold block uppercase tracking-wide text-blueGray-600">5</span>
+                                    <span class="text-xl font-bold block uppercase tracking-wide text-blueGray-600" th:text="${completeTradeCount}"></span>
                                     <span class="text-sm text-blueGray-400">거래</span>
                                 </div>
-                                <div class="mr-4 p-3 text-center">
-                                    <span class="text-xl font-bold block uppercase tracking-wide text-blueGray-600">10</span>
-                                    <span class="text-sm text-blueGray-400">리뷰</span>
-                                </div>
-                                <div class="lg:mr-4 p-3 text-center">
-                                    <span class="text-xl font-bold block uppercase tracking-wide text-blueGray-600">20</span>
-                                    <span class="text-sm text-blueGray-400">별점</span>
+                                <div class="p-3 text-center">
+                                    <a th:href="@{/review/list/{id}(id=${member.id})}">
+                                        <span class="text-xl font-bold block uppercase tracking-wide text-blueGray-600" th:text="${reviewCount}"></span>
+                                        <span class="text-sm text-blueGray-400">리뷰</span>
+                                    </a>
                                 </div>
                             </div>
-                        </div>
-                    </div>
-                    <div class="text-center mt-4">
-                        <h3 class="text-xl font-semibold leading-normal mb-2 text-blueGray-700 mb-2">
-                            이름
-                        </h3>
-                        <div class="text-sm leading-normal mt-0 mb-2 text-blueGray-400 font-bold uppercase">
-                            <i class="fas fa-map-marker-alt mr-2 text-lg text-blueGray-400"></i>
-                            주 활동지?
-                        </div>
-                        <div class="mb-2 text-blueGray-600 mt-5">
-                            <i class="fas fa-briefcase mr-2 text-lg text-blueGray-400"></i>
-                            쩝.........
-                        </div>
-                        <div class="mb-2 text-blueGray-600">
-                            <i class="fas fa-university mr-2 text-lg text-blueGray-400"></i>
-                            흠..........
                         </div>
                     </div>
                     <div class="mt-10 py-10 border-t border-blueGray-200 text-center">

--- a/src/main/resources/templates/usr/member/usrCheck.html
+++ b/src/main/resources/templates/usr/member/usrCheck.html
@@ -65,7 +65,7 @@
                                 <div class="p-3 text-center">
                                     <a th:href="@{/review/list/{id}(id=${member.id})}">
                                         <span class="text-xl font-bold block uppercase tracking-wide text-blueGray-600" th:text="${reviewCount}"></span>
-                                        <span class="text-sm text-blueGray-400">리뷰</span>
+                                        <span class="text-sm text-blueGray-400">후기</span>
                                     </a>
                                 </div>
                             </div>

--- a/src/test/java/com/ant/hurry/boundedContext/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/ant/hurry/boundedContext/member/controller/MemberControllerTest.java
@@ -1,0 +1,77 @@
+package com.ant.hurry.boundedContext.member.controller;
+
+import com.ant.hurry.boundedContext.member.service.MemberService;
+import com.ant.hurry.boundedContext.review.controller.ReviewController;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    MemberService memberService;
+
+
+    @Test
+    @DisplayName("유효하지 않는 멤버 id의 프로필 조회")
+    @WithUserDetails("user1")
+    void profile_member_not_exists() throws Exception {
+
+        //given
+        Long memberId = 999L;
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/usr/member/profile/{memberId}", memberId)).andDo(print());
+
+        //then
+        resultActions.andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("showProfile"))
+                .andExpect(model().attributeDoesNotExist("member"))
+                .andExpect(view().name("common/js"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("user1의 프로필 조회")
+    @WithUserDetails("user1")
+    void profile_member_exists() throws Exception {
+
+        //given
+        Long memberId = 1L;
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                get("/usr/member/profile/{memberId}", memberId)).andDo(print());
+
+        //then
+        resultActions.andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("showProfile"))
+                .andExpect(model().attributeExists("member"))
+                .andExpect(model().attributeExists("completeTradeCount"))
+                .andExpect(model().attributeExists("reviewCount"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("usr/member/usrCheck"));
+    }
+
+}

--- a/src/test/java/com/ant/hurry/boundedContext/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ant/hurry/boundedContext/member/service/MemberServiceTest.java
@@ -1,0 +1,44 @@
+package com.ant.hurry.boundedContext.member.service;
+
+import com.ant.hurry.base.rsData.RsData;
+import com.ant.hurry.boundedContext.member.entity.Member;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+
+    @Test
+    @DisplayName("프로필 멤버의 id가 유효하지 않으면 실패 처리")
+    @WithUserDetails("user1")
+    void profile_member_not_exists() {
+
+        //given
+        Long memberId = 999L;
+
+        //when
+        RsData<Member> rsData = memberService.validateAndReturnMember(memberId);
+
+        //then
+        assertAll(
+                () -> assertThat(rsData.getResultCode()).isEqualTo("F_M-2"),
+                () -> assertThat(rsData.getMsg()).isEqualTo("접근할 수 있는 권한이 없습니다.")
+        );
+    }
+
+}

--- a/src/test/java/com/ant/hurry/boundedContext/tradeStatus/service/TradeStatusServiceTest.java
+++ b/src/test/java/com/ant/hurry/boundedContext/tradeStatus/service/TradeStatusServiceTest.java
@@ -137,4 +137,19 @@ public class TradeStatusServiceTest {
     }
 
 
+    @Test
+    @DisplayName("유효한 거래 완료 횟수를 반환한다.")
+    void tradeStatus_count_valid() {
+
+        //given
+        Long memberId = 6L;
+
+        //when
+        Long count = tradeStatusService.getComleteTradeStatusCount(memberId);
+
+        //then
+        assertThat(count).isEqualTo(2L);
+    }
+
+
 }


### PR DESCRIPTION
- 서비스 사용자의 프로필 페이지 기능 구현
- 서비스 사용자의 프로필 페이지 레이아웃 구현
- 서비스 사용자의 프로필 페이지 기능 테스트 코드 작성

후기 버튼을 누르면 해당 사용자에 대한 후기를 볼 수 있도록 구현했습니다.
거래에 대해서는 따로 링크를 연결하지 않았습니다.
이 외에도 추가하면 좋을 데이터들 생각나시는 거 있으시면 말씀해주세여~
<img src="https://github.com/AntHurry/AntHurry/assets/109746210/f4abef6a-b705-44f8-966d-244ebe516a2f" height= 400px>
close #75 
