### PR TITLE
fix: 인증된 사용자 로그인 후, common.js 파일이 보여지는 현상 제거

### DIFF
--- a/src/main/java/com/ant/hurry/base/security/SecurityConfig.java
+++ b/src/main/java/com/ant/hurry/base/security/SecurityConfig.java
@@ -21,9 +21,13 @@ public class SecurityConfig {
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .formLogin(
-                        formLogin -> formLogin.loginPage("/usr/member/login"))
+                        formLogin -> formLogin.loginPage("/usr/member/login")
+                                .defaultSuccessUrl("/",true)
+                )
                 .oauth2Login(
-                        oauth2Login -> oauth2Login.loginPage("/usr/member/login"))
+                        oauth2Login -> oauth2Login.loginPage("/usr/member/login")
+                                .defaultSuccessUrl("/", true)
+                )
                 .logout(
                         logout -> logout.logoutUrl("/usr/member/logout"));
 


### PR DESCRIPTION
## 해결과정

https://iseunghan.tistory.com/352
-> 해당 블로그를 보고 처음에는 이 문제인 줄 알았다. 이 블로그의 내용을 토대로 아래의 2문장을 추가해서 정적 리소스를 허용했었다.
* .requestMatchers("/reousrces/**", "/static/**").permitAll()
* .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
이렇게 설정 했는데 동일한 현상이 발생했다.

<br>

해결방안
```java
        http
                .formLogin(
                        formLogin -> formLogin.loginPage("/usr/member/login")
                                .defaultSuccessUrl("/",true)
                )
                .oauth2Login(
                        oauth2Login -> oauth2Login.loginPage("/usr/member/login")
                                .defaultSuccessUrl("/", true)
                )
                .logout(
                        logout -> logout.logoutUrl("/usr/member/logout"));
```
-> 로그인이 성공했을때,  SuccessUrl 을 "/" 로 설정해주었고, alwaysUse 옵션을 true로 해주었다. 
alwaysUser 옵션을 주지 않으면 동일한 현상이 반복된다.... -> 왜 그런지는 잘 모르겠다.
<br>

* Spring Security 는 기본적으로 로그인에 성공하면 "/" 로 리다이렉션 되는것으로 알고있다.
* 그래서 처음에 이것에 대한 시도를 해보지 않았다. alwayUse 옵션이 있다는 것도 몰랐다.

<br>

defaultSuccessUrl() 의 alwaysUse 옵션 사용 시 주의점 
* successHandler 를 사용하고 있다면 충돌이 일어날 가능성이 있기 때문에 무조건 false 옵션을 줘야한다.


## GPT의 대답
<img width="720" alt="image" src="https://github.com/AntHurry/AntHurry/assets/92236489/a4d7b9d0-0e43-4918-b5aa-dc1a712264ed">


close #105 