### PR TITLE
feat: Board 엔티티에서 Member LAZY 유지하기 위해 BoardDto 생성

### DIFF
--- a/src/main/java/com/ant/hurry/base/serializer/LazyLoadingSerializer.java
+++ b/src/main/java/com/ant/hurry/base/serializer/LazyLoadingSerializer.java
@@ -1,0 +1,13 @@
+package com.ant.hurry.base.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+/**나중에 JackSon 직렬화 문제가 있을 때 쓰면 되는 클래스**/
+public class LazyLoadingSerializer extends JsonSerializer<Object> {
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeNull();
+    }
+}

--- a/src/main/java/com/ant/hurry/boundedContext/board/controller/BoardController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/board/controller/BoardController.java
@@ -2,6 +2,7 @@ package com.ant.hurry.boundedContext.board.controller;
 
 import com.ant.hurry.base.rq.Rq;
 import com.ant.hurry.base.rsData.RsData;
+import com.ant.hurry.boundedContext.board.dto.BoardDto;
 import com.ant.hurry.boundedContext.board.dto.CreateConvertDTO;
 import com.ant.hurry.boundedContext.board.dto.CreateRequest;
 import com.ant.hurry.boundedContext.board.entity.Board;
@@ -152,7 +153,7 @@ public class BoardController {
 
         Region region = regionService.findByCode(code).orElseThrow();
 
-        Slice<Board> boards = boardService.getBoards(lastId, code, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardService.getBoards(lastId, code, PageRequest.ofSize(10));
 
         model.addAttribute("boards", boards.getContent());
         model.addAttribute("region", region);
@@ -166,7 +167,7 @@ public class BoardController {
     public ResponseEntity<?> enterRegion(@PathVariable("lastId") Long lastId,
                                          @RequestParam("code") String code) {
 
-        Slice<Board> boards = boardService.getBoards(lastId, code, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardService.getBoards(lastId, code, PageRequest.ofSize(10));
         Map<String, Object> map = new HashMap<>();
         map.put("boardList", boards.getContent());
         return ResponseEntity.ok(map);
@@ -187,7 +188,7 @@ public class BoardController {
     @GetMapping("/online")
     public String showOnlineBoard(@Valid SearchForm searchForm, Model model) {
 
-        Slice<Board> boards = boardService.getOnlineBoards(null, searchForm.getTitle(), TradeType.온라인 ,PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardService.getOnlineBoards(null, searchForm.getTitle(), TradeType.온라인 ,PageRequest.ofSize(10));
 
         model.addAttribute("boards", boards);
         model.addAttribute("content", searchForm.getTitle());
@@ -200,7 +201,7 @@ public class BoardController {
     public ResponseEntity<?> showOnlineBoard(@PathVariable("lastId") Long lastId,
                                               @RequestParam("title") String title) {
 
-        Slice<Board> boards = boardService.getOnlineBoards(lastId, title, TradeType.온라인, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardService.getOnlineBoards(lastId, title, TradeType.온라인, PageRequest.ofSize(10));
         Map<String, Object> map = new HashMap<>();
         map.put("boardList", boards.getContent());
         return ResponseEntity.ok(map);

--- a/src/main/java/com/ant/hurry/boundedContext/board/dto/BoardDto.java
+++ b/src/main/java/com/ant/hurry/boundedContext/board/dto/BoardDto.java
@@ -1,0 +1,47 @@
+package com.ant.hurry.boundedContext.board.dto;
+
+import com.ant.hurry.boundedContext.board.entity.Board;
+import com.ant.hurry.boundedContext.board.entity.BoardType;
+import com.ant.hurry.boundedContext.board.entity.TradeType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class BoardDto {
+
+    private Long id;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+    private String title;
+    private String content;
+    @Enumerated(EnumType.STRING)
+    private BoardType boardType;
+    @Enumerated(EnumType.STRING)
+    private TradeType tradeType;
+    private int rewardCoin;
+    private String regCode;
+    private String nickname;
+
+    public BoardDto(Board board) {
+        this.id = board.getId();
+        this.updatedAt = board.getUpdatedAt();
+        this.title = board.getTitle();
+        this.content = board.getContent();
+        this.boardType = board.getBoardType();
+        this.tradeType = board.getTradeType();
+        this.rewardCoin = board.getRewardCoin();
+        this.regCode = board.getRegCode();
+        this.nickname = board.getMember().getNickname();
+    }
+
+}

--- a/src/main/java/com/ant/hurry/boundedContext/board/entity/Board.java
+++ b/src/main/java/com/ant/hurry/boundedContext/board/entity/Board.java
@@ -39,7 +39,7 @@ public class Board extends BaseEntity {
     private String regCode;
 
 
-    @ManyToOne(fetch = FetchType.EAGER)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
     public void updateBoard(CreateRequest createRequest) {

--- a/src/main/java/com/ant/hurry/boundedContext/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/ant/hurry/boundedContext/board/repository/BoardRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.ant.hurry.boundedContext.board.repository;
 
+import com.ant.hurry.boundedContext.board.dto.BoardDto;
 import com.ant.hurry.boundedContext.board.entity.Board;
 import com.ant.hurry.boundedContext.board.entity.BoardType;
 import com.ant.hurry.boundedContext.board.entity.TradeType;
@@ -9,7 +10,7 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 public interface BoardRepositoryCustom {
-    Slice<Board> paginationNoOffsetBuilder(Long id, String code, Pageable pageable);
+    Slice<BoardDto> paginationNoOffsetBuilder(Long id, String code, Pageable pageable);
 
-    Slice<Board> onlineBoardPaginationNoOffsetBuilder(Long id, String content, TradeType tradeType, Pageable pageable);
+    Slice<BoardDto> onlineBoardPaginationNoOffsetBuilder(Long id, String content, TradeType tradeType, Pageable pageable);
 }

--- a/src/main/java/com/ant/hurry/boundedContext/board/repository/BoardRepositoryImpl.java
+++ b/src/main/java/com/ant/hurry/boundedContext/board/repository/BoardRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.ant.hurry.boundedContext.board.repository;
 
+import com.ant.hurry.boundedContext.board.dto.BoardDto;
 import com.ant.hurry.boundedContext.board.entity.Board;
 import com.ant.hurry.boundedContext.board.entity.BoardType;
 import com.ant.hurry.boundedContext.board.entity.TradeType;
@@ -19,7 +20,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<Board> paginationNoOffsetBuilder(Long id, String code, Pageable pageable) {
+    public Slice<BoardDto> paginationNoOffsetBuilder(Long id, String code, Pageable pageable) {
         // id < 파라미터를 첫 페이지에서는 사용하지 않기 위한 동적 쿼리
         BooleanExpression idLt = id != null ? board.id.lt(id) : null;
         BooleanExpression codeEq = code != null ? board.regCode.eq(code) : null;
@@ -34,7 +35,7 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
     }
 
     //무한 스크롤 방식 처리
-    private Slice<Board> checkLastPage(Pageable pageable, List<Board> results) {
+    private Slice<BoardDto> checkLastPage(Pageable pageable, List<Board> results) {
         boolean hasNext = false;
 
         if (results.size() > pageable.getPageSize()) {
@@ -42,11 +43,12 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom {
             results.remove(pageable.getPageSize());
         }
 
-        return new SliceImpl<>(results, pageable, hasNext);
+        List<BoardDto> dtos = results.stream().map(BoardDto::new).toList();
+        return new SliceImpl<>(dtos, pageable, hasNext);
     }
 
     @Override
-    public Slice<Board> onlineBoardPaginationNoOffsetBuilder(Long id, String content, TradeType tradeType, Pageable pageable) {
+    public Slice<BoardDto> onlineBoardPaginationNoOffsetBuilder(Long id, String content, TradeType tradeType, Pageable pageable) {
         BooleanExpression idLt = id != null ? board.id.lt(id) : null;
         BooleanExpression tradeTypeEq = tradeType != null ? board.tradeType.eq(tradeType) : null;
 

--- a/src/main/java/com/ant/hurry/boundedContext/board/service/BoardService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/board/service/BoardService.java
@@ -6,6 +6,7 @@ import com.ant.hurry.base.api.service.KakaoAddressSearchService;
 import com.ant.hurry.base.region.repository.RegionRepository;
 import com.ant.hurry.base.rq.Rq;
 import com.ant.hurry.base.rsData.RsData;
+import com.ant.hurry.boundedContext.board.dto.BoardDto;
 import com.ant.hurry.boundedContext.board.dto.CreateConvertDTO;
 import com.ant.hurry.boundedContext.board.dto.CreateRequest;
 import com.ant.hurry.boundedContext.board.entity.Board;
@@ -166,12 +167,12 @@ public class BoardService {
         return boardRepository.findByTradeTypeAndBoardTypeAndTitleContaining(tradeType, boardType, title);
     }
 
-    public Slice<Board> getBoards(Long lastId, String code, Pageable pageable) {
+    public Slice<BoardDto> getBoards(Long lastId, String code, Pageable pageable) {
         return boardRepository.paginationNoOffsetBuilder(lastId, code, pageable);
     }
 
 
-    public Slice<Board> getOnlineBoards(Long id, String title, TradeType tradeType, PageRequest pageRequest) {
+    public Slice<BoardDto> getOnlineBoards(Long id, String title, TradeType tradeType, PageRequest pageRequest) {
         return boardRepository.onlineBoardPaginationNoOffsetBuilder(id, title, tradeType, pageRequest);
     }
 }

--- a/src/main/resources/data_h2.sql
+++ b/src/main/resources/data_h2.sql
@@ -5,7 +5,6 @@ INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, prov
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('user5', 'User5', 'password123', '01056789012', 1, 'kakao', 0, 0, 0);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('admin', 'admin', 'password123', '01026749612', 1, 'kakao', 0, 0, 0);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('KAKAO__12345678', 'bigsand', 'password12311', '01053833333', 1, 'kakao', 0, 0, 0);
-INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('KAKAO__2863095386', 'donggi', 'password12311', '01000000000', 1, 'KAKAO', 100000, 0, 0);
 
 INSERT INTO NOTIFICATION (requester_id, helper_id, message, type, created_at) VALUES (1, 2, '채팅시작테스트', 'START', NOW());
 INSERT INTO NOTIFICATION (requester_id, helper_id, message, type, created_at) VALUES (1, 3, '거래취소테스트', 'CANCEL', NOW());
@@ -66,7 +65,7 @@ insert into BOARD (reward_coin, x, y, board_type, content, reg_code, title, trad
 insert into BOARD (reward_coin, x, y, board_type, content, reg_code, title, trade_type, member_id) VALUES(10, 126.732240699017, 37.5110124805355, '나급해요', '내용47', '2823710500', '제목47', '온라인', 1);
 insert into BOARD (reward_coin, x, y, board_type, content, reg_code, title, trade_type, member_id) VALUES(10, 126.732240699017, 37.5110124805355, '나급해요', '내용48', '2823710500', '제목48', '온라인', 1);
 insert into BOARD (reward_coin, x, y, board_type, content, reg_code, title, trade_type, member_id) VALUES(10, 126.732240699017, 37.5110124805355, '나급해요', '내용49', '2823710500', '제목49', '온라인', 1);
-insert into BOARD (reward_coin, x, y, board_type, content, reg_code, title, trade_type, member_id) VALUES(10, 126.732240699017, 37.5110124805355, '나급해요', '내용50', '2823710500', '제목50', '온라인', 8);
+insert into BOARD (reward_coin, x, y, board_type, content, reg_code, title, trade_type, member_id) VALUES(10, 126.732240699017, 37.5110124805355, '나급해요', '내용50', '2823710500', '제목50', '온라인', 1);
 
 
 

--- a/src/main/resources/templates/board/enterRegion.html
+++ b/src/main/resources/templates/board/enterRegion.html
@@ -48,8 +48,8 @@
                                 <span class="card-title" th:text="${board.title}"></span>
                                 <span class="text-xs mt-1 ml-auto" th:text="${board.boardType}"></span>
                             </div>
-                            <span class="text-xs mb-1" th:if="${board.member != null}"
-                                  th:text="${board.member.nickname}"></span>
+                            <span class="text-xs mb-1" th:if="${board.nickname != null}"
+                                  th:text="${board.nickname}"></span>
                             <div class="flex">
                                 <span th:text="${board.rewardCoin}" class="pr-1"></span>
                                 <img class="w-6 h-6" src="https://cdn-icons-png.flaticon.com/128/1490/1490853.png"
@@ -99,7 +99,7 @@
 
                 const memberNickname = document.createElement('span');
                 memberNickname.setAttribute('class', 'text-xs mb-1');
-                memberNickname.innerText = board.member.nickname;
+                memberNickname.innerText = board.nickname;
 
                 const cardBodyFlex2 = document.createElement('div');
                 cardBodyFlex2.setAttribute('class', 'flex');

--- a/src/main/resources/templates/board/online.html
+++ b/src/main/resources/templates/board/online.html
@@ -38,8 +38,8 @@
                                 <span class="card-title" th:text="${board.title}"></span>
                                 <span class="text-xs mt-1 ml-auto" th:text="${board.boardType}"></span>
                             </div>
-                            <span class="text-xs mb-1" th:if="${board.member != null}"
-                                  th:text="${board.member.nickname}"></span>
+                            <span class="text-xs mb-1" th:if="${board.nickname != null}"
+                                  th:text="${board.nickname}"></span>
                             <div class="flex">
                                 <span th:text="${board.rewardCoin}" class="pr-1"></span>
                                 <img class="w-6 h-6" src="https://cdn-icons-png.flaticon.com/128/1490/1490853.png"
@@ -89,7 +89,7 @@
 
                 const memberNickname = document.createElement('span');
                 memberNickname.setAttribute('class', 'text-xs mb-1');
-                memberNickname.innerText = board.member.nickname;
+                memberNickname.innerText = board.nickname;
 
                 const cardBodyFlex2 = document.createElement('div');
                 cardBodyFlex2.setAttribute('class', 'flex');
@@ -128,7 +128,7 @@
 
 
             const url = `/board/online/${lastId2}?title=${boardSearch}`;
-            console.log(url);
+
             fetch(url)
                 .then((response) => response.json())
                 .then(data => {

--- a/src/main/resources/templates/usr/member/login.html
+++ b/src/main/resources/templates/usr/member/login.html
@@ -1,7 +1,7 @@
 <html layout:decorate="~{usr/layout/layout.html}">
 
 <head>
-    <title>로그인 페이지</title>
+    <title>로그인</title>
 </head>
 
 <body>
@@ -34,7 +34,7 @@
             </div>
         </div>
         <div class="navbar-center">
-            <a class="font-black">로그인 페이지</a>
+            <a class="font-black">로그인</a>
         </div>
         <div class="navbar-end">
             <button class="btn btn-ghost btn-circle">
@@ -48,14 +48,11 @@
     <div class="body bg-white dark:bg-[#0F172A]">
         <div class="bg-black before:animate-pulse before:bg-gradient-to-b before:from-gray-900 overflow-hidden before:via-[#FF626F] before:to-gray-900 before:absolute ">
             <div id="myDIV">
-                <div class="w-[100vw] h-[100vh] px-3 sm:px-5 flex items-center justify-center absolute">
+                <div class="w-[100vw] h-[85vh] px-3 sm:px-5 flex items-center justify-center absolute">
                     <div class="w-full sm:w-1/2 lg:2/3 px-6 bg-gray-500 bg-opacity-20 bg-clip-padding backdrop-filter backdrop-blur-sm text-white z-50 py-4  rounded-lg">
-                        <div class="w-full flex justify-center text-[#FF626F] text-xl mb:2 md:mb-5">
-                            로그인
-                        </div>
 
                         <div class="text-center mt-2">
-                            <a href="/oauth2/authorization/naver" class="btn w-full gap-1">
+                            <a href="/oauth2/authorization/naver" class="btn border border-slate-600 bg-slate-700 text-slate-300 w-full gap-1">
                                 <i class="fa-solid fa-n text-[color:#2DB400]"></i>
                                 <span class="normal-case">네이버 로그인</span>
                             </a>
@@ -67,7 +64,7 @@
                         </div>
                         <div class="text-center mt-2">
                                 <!-- 로그인하지 않은 경우, 로그인 버튼을 보여줌 -->
-                                <a href="/oauth2/authorization/kakao" class="btn w-full gap-1">
+                                <a href="/oauth2/authorization/kakao" class="btn border border-slate-600 bg-slate-700 text-slate-300 w-full gap-1">
                                     <i class="fa-solid fa-comment text-[color:#ffe812]"></i>
                                     <span class="normal-case">카카오 로그인</span>
                                 </a>

--- a/src/test/java/com/ant/hurry/boundedContext/board/service/BoardServiceTest.java
+++ b/src/test/java/com/ant/hurry/boundedContext/board/service/BoardServiceTest.java
@@ -3,6 +3,7 @@ package com.ant.hurry.boundedContext.board.service;
 import com.ant.hurry.base.region.service.RegionSearchService;
 import com.ant.hurry.base.rq.Rq;
 import com.ant.hurry.base.rsData.RsData;
+import com.ant.hurry.boundedContext.board.dto.BoardDto;
 import com.ant.hurry.boundedContext.board.dto.CreateRequest;
 import com.ant.hurry.boundedContext.board.entity.Board;
 import com.ant.hurry.boundedContext.board.entity.BoardType;
@@ -120,7 +121,7 @@ public class BoardServiceTest {
 
 
         //when
-        Slice<Board> boards = boardRepository.paginationNoOffsetBuilder(null, "2823710500", PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.paginationNoOffsetBuilder(null, "2823710500", PageRequest.ofSize(10));
 
         //then
         assertThat(boards.getContent().size()).isEqualTo(10);
@@ -134,7 +135,7 @@ public class BoardServiceTest {
     void noOffSet2() throws Exception {
 
         //when
-        Slice<Board> boards = boardRepository.paginationNoOffsetBuilder(41L, "2823710500", PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.paginationNoOffsetBuilder(41L, "2823710500", PageRequest.ofSize(10));
 
         //then
         assertThat(boards.getContent().size()).isEqualTo(10);
@@ -148,13 +149,13 @@ public class BoardServiceTest {
     void checkLast() throws Exception {
 
         //when
-        Slice<Board> boards = boardRepository.paginationNoOffsetBuilder(21L, "2823710500", PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.paginationNoOffsetBuilder(21L, "2823710500", PageRequest.ofSize(10));
 
         //then
         assertThat(boards.isLast()).isFalse();
 
         //when
-        Slice<Board> boards2 = boardRepository.paginationNoOffsetBuilder(11L, "2823710500", PageRequest.ofSize(10));
+        Slice<BoardDto> boards2 = boardRepository.paginationNoOffsetBuilder(11L, "2823710500", PageRequest.ofSize(10));
 
         //then
         assertThat(boards2.isLast()).isTrue();
@@ -166,7 +167,7 @@ public class BoardServiceTest {
     void onlineBoard() throws Exception {
 
         //when
-        Slice<Board> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(null, "제목", TradeType.온라인, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(null, "제목", TradeType.온라인, PageRequest.ofSize(10));
 
         //then
         assertThat(boards.getContent().size()).isEqualTo(10);
@@ -180,7 +181,7 @@ public class BoardServiceTest {
     void onlineBoard2() throws Exception {
 
         //when
-        Slice<Board> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(41L, "제목", TradeType.온라인, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(41L, "제목", TradeType.온라인, PageRequest.ofSize(10));
 
         //then
         assertThat(boards.getContent().size()).isEqualTo(10);
@@ -194,13 +195,13 @@ public class BoardServiceTest {
     void onlineBoardLast() throws Exception {
 
         //when
-        Slice<Board> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(null, "제목", TradeType.온라인, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(null, "제목", TradeType.온라인, PageRequest.ofSize(10));
 
         //then
         assertThat(boards.isLast()).isFalse();
 
         //when
-        Slice<Board> boards2 = boardRepository.onlineBoardPaginationNoOffsetBuilder(41L, "제목", TradeType.온라인, PageRequest.ofSize(10));
+        Slice<BoardDto> boards2 = boardRepository.onlineBoardPaginationNoOffsetBuilder(41L, "제목", TradeType.온라인, PageRequest.ofSize(10));
 
         //then
         assertThat(boards2.isLast()).isTrue();
@@ -212,7 +213,7 @@ public class BoardServiceTest {
     void onlineBoardEmpty() throws Exception {
 
         //when
-        Slice<Board> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(null, "없는 제목", TradeType.온라인, PageRequest.ofSize(10));
+        Slice<BoardDto> boards = boardRepository.onlineBoardPaginationNoOffsetBuilder(null, "없는 제목", TradeType.온라인, PageRequest.ofSize(10));
 
         //then
         assertThat(boards.getContent().size()).isEqualTo(0);


### PR DESCRIPTION
BoardDto 생성해서 Board 엔티티의 Member 변수의 LAZY 유지하였습니다.

로그인 페이지 다음과 같이 변경했는데 괜찮을까요?

<img width="425" alt="image" src="https://github.com/AntHurry/AntHurry/assets/108447799/3bd9a163-a911-4153-8a4f-7bf764625d13">

resolve #101 