### PR TITLE
Fix/authority : 권한 분리

### DIFF
--- a/src/main/java/com/ant/hurry/base/initData/DataLoader.java
+++ b/src/main/java/com/ant/hurry/base/initData/DataLoader.java
@@ -1,4 +1,4 @@
-//package com.ant.hurry.base.initData;
+package com.ant.hurry.base.initData;
 //
 //import com.ant.hurry.boundedContext.member.entity.Member;
 //import com.ant.hurry.boundedContext.member.repository.MemberRepository;
@@ -43,3 +43,30 @@
 ////        memberRepository.save(admin);
 ////    }
 //}
+
+import com.ant.hurry.boundedContext.member.entity.Role;
+import com.ant.hurry.boundedContext.member.entity.RoleType;
+import com.ant.hurry.boundedContext.member.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DataLoader implements CommandLineRunner {
+
+    private final RoleRepository roleRepository;
+
+    @Override
+    public void run(String... args) throws Exception {
+        if (roleRepository.findByName(RoleType.ROLE_ADMIN).isEmpty()) {
+            Role adminRole = new Role(RoleType.ROLE_ADMIN);
+            roleRepository.save(adminRole);
+        }
+
+        if (roleRepository.findByName(RoleType.ROLE_MEMBER.ROLE_MEMBER).isEmpty()) {
+            Role memberRole = new Role(RoleType.ROLE_MEMBER);
+            roleRepository.save(memberRole);
+        }
+    }
+}

--- a/src/main/java/com/ant/hurry/base/security/SecurityConfig.java
+++ b/src/main/java/com/ant/hurry/base/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .logout(
                         logout -> logout.logoutUrl("/usr/member/logout"));
 
-//        http.addFilterBefore(new PhoneAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new PhoneAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/chat/**", "/pub/**", "/sub/**").permitAll()

--- a/src/main/java/com/ant/hurry/base/security/SecurityConfig.java
+++ b/src/main/java/com/ant/hurry/base/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig {
                 .logout(
                         logout -> logout.logoutUrl("/usr/member/logout"));
 
-        http.addFilterBefore(new PhoneAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+//        http.addFilterBefore(new PhoneAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/chat/**", "/pub/**", "/sub/**").permitAll()

--- a/src/main/java/com/ant/hurry/boundedContext/adm/controller/AdmController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/adm/controller/AdmController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/adm")
-@PreAuthorize("hasAuthority('admin')")
+@PreAuthorize("hasAuthority('ROLE_ADMIN')")
 public class AdmController {
 
     private final AdmService admService;

--- a/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/controller/MemberController.java
@@ -179,18 +179,7 @@ public class MemberController {
         return "usr/member/profile_edit";
     }
 
-//    @PreAuthorize("isAuthenticated()")
-//    @PostMapping("/profile_edit")
-//    public String updateProfile(@ModelAttribute @Valid ProfileRequestDto profileRequestDto, BindingResult bindingResult,
-//                                MultipartFile file) throws IOException {
-//        if (bindingResult.hasErrors()) {
-//            return "/usr/member/profile_edit";
-//        }
-//        Member member = rq.getMember();
-//        memberService.updateProfile(member, profileRequestDto.getNickname(), file);
-//
-//        return "redirect:/usr/member/profile";
-//    }
+
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping(value = "/profile_edit", produces = "application/json;utf-8;")

--- a/src/main/java/com/ant/hurry/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/entity/Member.java
@@ -1,8 +1,7 @@
 package com.ant.hurry.boundedContext.member.entity;
 
 import com.ant.hurry.base.baseEntity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +11,9 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -66,14 +67,21 @@ public class Member extends BaseEntity {
 
     private int reviewCount = 0;
 
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+            name = "member_roles",
+            joinColumns = @JoinColumn(name = "member_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
 
     public List<? extends GrantedAuthority> getGrantedAuthorities() {
         List<GrantedAuthority> grantedAuthorities = new ArrayList<>();
 
-        grantedAuthorities.add(new SimpleGrantedAuthority("member"));
-
-        if ("admin".equals(nickname)) {
-            grantedAuthorities.add(new SimpleGrantedAuthority("admin"));
+        if(this.roles != null){
+            for (Role role : this.roles) {
+                grantedAuthorities.add(new SimpleGrantedAuthority(role.getName().toString()));
+            }
         }
 
         return grantedAuthorities;

--- a/src/main/java/com/ant/hurry/boundedContext/member/entity/Member.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/entity/Member.java
@@ -46,7 +46,7 @@ public class Member extends BaseEntity {
 
 
     public boolean isPhoneAuth(){
-        if(phoneAuth == 1 && !phoneNumber.trim().equals("") && !phoneNumber.isEmpty())
+        if(phoneAuth == 1 && phoneNumber != null)
             return true;
         return false;
     }

--- a/src/main/java/com/ant/hurry/boundedContext/member/entity/Role.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/entity/Role.java
@@ -1,0 +1,24 @@
+package com.ant.hurry.boundedContext.member.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType name;
+
+    public Role(RoleType name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/ant/hurry/boundedContext/member/entity/RoleType.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/entity/RoleType.java
@@ -1,0 +1,5 @@
+package com.ant.hurry.boundedContext.member.entity;
+
+public enum RoleType {
+    ROLE_MEMBER, ROLE_ADMIN
+}

--- a/src/main/java/com/ant/hurry/boundedContext/member/repository/RoleRepository.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/repository/RoleRepository.java
@@ -1,0 +1,12 @@
+package com.ant.hurry.boundedContext.member.repository;
+
+import com.ant.hurry.boundedContext.member.entity.Role;
+import com.ant.hurry.boundedContext.member.entity.RoleType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(RoleType roleName);
+}

--- a/src/main/java/com/ant/hurry/boundedContext/member/service/MemberService.java
+++ b/src/main/java/com/ant/hurry/boundedContext/member/service/MemberService.java
@@ -52,7 +52,7 @@ public class MemberService {
             return RsData.of("S-2", "로그인 되었습니다.", opMember.get());
 
         // 소셜 로그인를 통한 가입시 비번은 없다.
-        return createAndSave(username, "", "", providerTypeCode); // 최초 로그인 시 딱 한번 실행
+        return createAndSave(username, "", null, providerTypeCode); // 최초 로그인 시 딱 한번 실행
     }
 
     private RsData<Member> createAndSave(String username, String password, String phone, String providerTypeCode) {

--- a/src/main/resources/data_h2.sql
+++ b/src/main/resources/data_h2.sql
@@ -1,10 +1,20 @@
+INSERT INTO ROLE (name) values ('ROLE_ADMIN');
+INSERT INTO ROLE (name) values ('ROLE_MEMBER');
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('user1', 'User1', 'password123', '01012345678', 1, 'kakao', 1000, 3.5, 1);
+INSERT INTO member_roles (member_id, role_id) VALUES (1, 2);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('user2', 'User2', 'password123', '01023456789', 1, 'kakao', 0, 5.0, 1);
+INSERT INTO member_roles (member_id, role_id) VALUES (2, 2);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('user3', 'User3', 'password123', '01034567890', 1, 'kakao', 0, 1.0, 2);
+INSERT INTO member_roles (member_id, role_id) VALUES (3, 2);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('user4', 'User4', 'password123', '01045678901', 1, 'kakao', 0, 3.5, 2);
+INSERT INTO member_roles (member_id, role_id) VALUES (4, 2);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('user5', 'User5', 'password123', '01056789012', 1, 'kakao', 0, 0, 0);
+INSERT INTO member_roles (member_id, role_id) VALUES (5, 2);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('admin', 'admin', 'password123', '01026749612', 1, 'kakao', 0, 0, 0);
+INSERT INTO member_roles (member_id, role_id) VALUES (6, 1);
+INSERT INTO member_roles (member_id, role_id) VALUES (6, 2);
 INSERT INTO MEMBER (username, nickname, password, phone_number, phone_auth, provider_type_code, coin, rating, review_count) VALUES ('KAKAO__12345678', 'bigsand', 'password12311', '01053833333', 1, 'kakao', 0, 0, 0);
+INSERT INTO member_roles (member_id, role_id) VALUES (7, 2);
 
 INSERT INTO NOTIFICATION (requester_id, helper_id, message, type, created_at) VALUES (1, 2, '채팅시작테스트', 'START', NOW());
 INSERT INTO NOTIFICATION (requester_id, helper_id, message, type, created_at) VALUES (1, 3, '거래취소테스트', 'CANCEL', NOW());

--- a/src/main/resources/templates/usr/member/profile_edit.html
+++ b/src/main/resources/templates/usr/member/profile_edit.html
@@ -125,7 +125,6 @@
           'Accept': 'application/json'  // Accept 헤더 설정
         },
         success: function(response) {
-          alert(response.data);
           alert('프로필 업데이트 완료');
           window.location.href= window.location.origin + "/usr/member/profile";
         },

--- a/src/test/java/com/ant/hurry/boundedContext/member/service/MemberServiceUnitTest.java
+++ b/src/test/java/com/ant/hurry/boundedContext/member/service/MemberServiceUnitTest.java
@@ -6,8 +6,11 @@ import com.ant.hurry.base.s3.S3ProfileUploader;
 import com.ant.hurry.boundedContext.coin.service.CoinService;
 import com.ant.hurry.boundedContext.member.entity.Member;
 import com.ant.hurry.boundedContext.member.entity.ProfileImage;
+import com.ant.hurry.boundedContext.member.entity.Role;
+import com.ant.hurry.boundedContext.member.entity.RoleType;
 import com.ant.hurry.boundedContext.member.repository.MemberRepository;
 import com.ant.hurry.boundedContext.member.repository.ProfileImageRepository;
+import com.ant.hurry.boundedContext.member.repository.RoleRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +47,9 @@ class MemberServiceUnitTest {
     @Mock
     ProfileImageRepository profileImageRepository;
 
+    @Mock
+    RoleRepository roleRepository;
+
 
     @Test
     @DisplayName("whenSocialLogin() - 기존 사용자 로그인")
@@ -73,9 +79,10 @@ class MemberServiceUnitTest {
         String providerTypeCode = "KAKAO";
 
         Member member = new Member();
+        Optional<Role> role = Optional.of(new Role(RoleType.ROLE_MEMBER));
         when(memberRepository.findByUsername(username)).thenReturn(Optional.empty());
         when(memberRepository.save(any(Member.class))).thenReturn(member);
-
+        when(roleRepository.findByName(RoleType.ROLE_MEMBER)).thenReturn(role);
         //when
         RsData<Member> result = memberService.whenSocialLogin(providerTypeCode, username);
 


### PR DESCRIPTION
- [x] 관리자 권한 데이터 베이스로 분리
  - [x] 관리자 권한 분리 후, data_h2.sql 초기 데이터 Member 권한 부여 
  - [x] 관리자 권한 추가하면서 깨진 테스트 케이스 수정
- [x] 회원가입 시, phone_number 빈 문자열 들어가서 오류나는거 수정



## 관리자 권한 부여(With Mysql Workbench)
```sql
-- member_roles 테이블에 Member id와 Role id를 매핑하여 추가하고 확인한다.
INSERT INTO member_roles (member_id, role_id) VALUES (9, 1); # role_id 1번이 관리자
select * from member_roles;
```
* DataLoader.java 파일에 서버 실행 시 권한 2개 생성되도록 했습니다. -> ROLE_ADMIN, ROLE_MEMBER
  * 1번 관리자
  * 2번 일반사용자

close #118 