### PR TITLE
Feature/sendFile : 채팅방, 채팅 목록 로직 및 html 수정

### DIFF
--- a/src/main/java/com/ant/hurry/boundedContext/tradeStatus/controller/TradeStatusController.java
+++ b/src/main/java/com/ant/hurry/boundedContext/tradeStatus/controller/TradeStatusController.java
@@ -95,14 +95,16 @@ public class TradeStatusController {
     public String start(@PathVariable Long id) {
         TradeStatus tradeStatus = tradeStatusService.findById(id).getData();
         RsData<TradeStatus> rs = tradeStatusService.updateStatus(tradeStatus, INPROGRESS);
-        return rq.historyBack(rs.getMsg());
+        ChatRoom chatRoom = chatRoomService.findByTradeStatusId(rs.getData().getId()).getData();
+        return rq.redirectWithMsg("chat/room/%s".formatted(chatRoom.getId()), rs.getMsg());
     }
 
     @GetMapping("/complete/{id}")
     public String complete(@PathVariable Long id) {
         TradeStatus tradeStatus = tradeStatusService.findById(id).getData();
         RsData<TradeStatus> rs = tradeStatusService.updateStatus(tradeStatus, COMPLETE);
-        return rq.historyBack(rs.getMsg());
+        ChatRoom chatRoom = chatRoomService.findByTradeStatusId(rs.getData().getId()).getData();
+        return rq.redirectWithMsg("chat/room/%s".formatted(chatRoom.getId()), rs.getMsg());
     }
 
 }

--- a/src/main/java/com/ant/hurry/chat/baseEntity/Message.java
+++ b/src/main/java/com/ant/hurry/chat/baseEntity/Message.java
@@ -3,4 +3,5 @@ package com.ant.hurry.chat.baseEntity;
 public interface Message {
     String getMessage();
     boolean isNotRead();
+    void markAsRead();
 }

--- a/src/main/java/com/ant/hurry/chat/baseEntity/Message.java
+++ b/src/main/java/com/ant/hurry/chat/baseEntity/Message.java
@@ -4,4 +4,5 @@ public interface Message {
     String getMessage();
     boolean isNotRead();
     void markAsRead();
+    boolean isFileMessage();
 }

--- a/src/main/java/com/ant/hurry/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/ant/hurry/chat/controller/ChatMessageController.java
@@ -9,7 +9,6 @@ import com.ant.hurry.chat.service.ChatMessageService;
 import com.ant.hurry.chat.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -35,11 +34,17 @@ public class ChatMessageController {
         messagingTemplate.convertAndSend("/sub/chat/room/%s".formatted(dto.getRoomId()), dto);
     }
 
-    @MessageMapping("/chat/file")
-    public void sendFileMessage(@RequestParam String roomId, @Payload MultipartFile file) throws IOException {
+    @PostMapping("/file")
+    public void sendFile(@RequestParam String roomId, @Payload MultipartFile file) throws IOException {
         ChatRoom chatRoom = chatRoomService.findById(roomId).getData();
         RsData<ChatFileMessage> rs = chatMessageService.sendFile(file, rq.getMember(), chatRoom);
         ChatFileMessage message = rs.getData();
+
+        sendFileMessage(roomId, message);
+    }
+
+    @MessageMapping("/chat/file")
+    public void sendFileMessage(String roomId, ChatFileMessage message) {
         messagingTemplate.convertAndSend("/sub/chat/room/%s".formatted(roomId), message);
     }
 

--- a/src/main/java/com/ant/hurry/chat/entity/ChatFileMessage.java
+++ b/src/main/java/com/ant/hurry/chat/entity/ChatFileMessage.java
@@ -37,4 +37,9 @@ public class ChatFileMessage extends BaseMessage implements Message {
     public String getMessage() {
         return "파일을 다운로드할 수 있습니다.";
     }
+
+    @Override
+    public boolean isFileMessage() {
+        return true;
+    }
 }

--- a/src/main/java/com/ant/hurry/chat/entity/ChatFileMessage.java
+++ b/src/main/java/com/ant/hurry/chat/entity/ChatFileMessage.java
@@ -19,7 +19,7 @@ public class ChatFileMessage extends BaseMessage implements Message {
 
     private String uploadFileId;
 
-    private String sender;
+    private String writer;
 
     private LocalDateTime deletedAt;
 

--- a/src/main/java/com/ant/hurry/chat/entity/ChatMessage.java
+++ b/src/main/java/com/ant/hurry/chat/entity/ChatMessage.java
@@ -30,4 +30,9 @@ public class ChatMessage extends BaseMessage implements Message {
     public boolean isNotRead() {
         return readAt == null;
     }
+
+    @Override
+    public boolean isFileMessage() {
+        return false;
+    }
 }

--- a/src/main/java/com/ant/hurry/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ant/hurry/chat/service/ChatMessageService.java
@@ -3,6 +3,7 @@ package com.ant.hurry.chat.service;
 import com.ant.hurry.base.rsData.RsData;
 import com.ant.hurry.boundedContext.member.entity.Member;
 import com.ant.hurry.boundedContext.member.service.MemberService;
+import com.ant.hurry.chat.baseEntity.BaseMessage;
 import com.ant.hurry.chat.baseEntity.Message;
 import com.ant.hurry.chat.config.MongoConfig;
 import com.ant.hurry.chat.dto.ChatMessageDto;
@@ -80,6 +81,7 @@ public class ChatMessageService {
                 .roomId(dto.getRoomId())
                 .writer(writer.getNickname())
                 .message(dto.getMessage())
+                .createdAt(LocalDateTime.now())
                 .build();
         chatMessageRepository.save(message);
 
@@ -184,6 +186,13 @@ public class ChatMessageService {
 
     private GridFSBucket createGridBucket() {
         return GridFSBuckets.create(mongoConfig.mongoClient().getDatabase(databaseName));
+    }
+
+    public void markAsRead(Message message) {
+        message.markAsRead();
+        if(message instanceof ChatMessage)
+            chatMessageRepository.save((ChatMessage) message);
+        else chatFileMessageRepository.save((ChatFileMessage) message);
     }
 
     public RsData deleteSoft(ChatMessage chatMessage) {

--- a/src/main/java/com/ant/hurry/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ant/hurry/chat/service/ChatMessageService.java
@@ -3,7 +3,6 @@ package com.ant.hurry.chat.service;
 import com.ant.hurry.base.rsData.RsData;
 import com.ant.hurry.boundedContext.member.entity.Member;
 import com.ant.hurry.boundedContext.member.service.MemberService;
-import com.ant.hurry.chat.baseEntity.BaseMessage;
 import com.ant.hurry.chat.baseEntity.Message;
 import com.ant.hurry.chat.config.MongoConfig;
 import com.ant.hurry.chat.dto.ChatMessageDto;
@@ -115,7 +114,7 @@ public class ChatMessageService {
                 .uploadFilePath(filePath)
                 .uploadFileId(fileId.toString())
                 .roomId(chatRoom.getId())
-                .sender(sender.getNickname())
+                .writer(sender.getNickname())
                 .createdAt(LocalDateTime.now())
                 .build();
         chatFileMessageRepository.insert(chatFileMessage);

--- a/src/main/resources/templates/chat/myRooms.html
+++ b/src/main/resources/templates/chat/myRooms.html
@@ -46,7 +46,7 @@
                    class="text-lg text-start"></p>
             </div>
             <div th:if="${chatRoom.getValue().message != null && @rq.getMember().getNickname() != chatRoom.getValue().sender && chatRoom.getValue().message.isNotRead()}"
-                 class="bg-[#ff626f] w-16 text-white font-semibold rounded-xl">new
+                 class="bg-[#ff626f] w-12 text-white text-center font-semibold rounded-xl">new
             </div>
         </a>
     </div>

--- a/src/main/resources/templates/chat/myRooms.html
+++ b/src/main/resources/templates/chat/myRooms.html
@@ -26,13 +26,13 @@
 
 </header>
 
-<main layout:fragment="main" class="flex-grow flex flex-col items-center w-full p-4">
-    <div th:if="${chatRooms.size() == 0}" class="text-lg text-gray-400 pt-12">
+<main layout:fragment="main" class="flex-grow flex flex-col w-full mx-auto max-w-sm p-4">
+    <div th:if="${chatRooms.size() == 0}" class="text-lg text-gray-400 pt-12 mx-auto">
         채팅 중인 대화방이 없습니다.<i class="fa-regular fa-face-sad-tear ml-2"></i>
     </div>
-    <div th:if="${!#lists.isEmpty(chatRooms)}">
+    <div th:if="${!#lists.isEmpty(chatRooms)}" class="max-w-xs">
         <a th:each="chatRoom : ${chatRooms}" th:href="@{/chat/room/{id}(id=${chatRoom.getKey().id})}"
-                class="hover:bg-gray-50 active:bg-gray-100 border-2 border-solid border-gray-100 rounded-lg w-[650px] px-8 py-6 mb-6 flex justify-between items-center">
+                class="hover:bg-gray-50 active:bg-gray-100 border-2 border-solid border-gray-100 w-[350px] rounded-lg px-8 py-6 mb-6 flex justify-between items-center">
             <div>
                 <div class="mb-2 text-start">
                     <span style="padding: 0;" th:if="${@rq.getMember().getNickname().equals(chatRoom.getKey().getMembersNickName().get(0))}"

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -39,7 +39,7 @@
     </div>
 </header>
 
-<main layout:fragment="main" class="flex-grow flex items-center justify-center w-screen h-[1000px] p-8">
+<main layout:fragment="main" class="flex-grow flex items-center justify-center w-screen h-[750px] p-8">
     <div id="chat-area" class="flex flex-col w-[650px] h-full">
         <div id="messages" class="flex text-center w-full justify-end" th:each="message : ${chatMessages}">
             <div class="chat chat-start" th:if="${!@rq.getMember().getNickname().equals(message.writer)}">
@@ -69,7 +69,7 @@
                 <form method="dialog" class="modal-box" enctype="multipart/form-data" th:action="@{/chat/file(roomId=${room.id})}">
                     <input type="file" class="file-input file-input-bordered file-input-sm w-full max-w-sm" name="file" />
                     <div class="modal-action">
-                        <button type="submit" class="btn">보내기</button>
+                        <button id="file-send" type="submit" class="btn">보내기</button>
                         <button class="btn">닫기</button>
                     </div>
                 </form>
@@ -129,6 +129,30 @@
                     writer: username
                 }));
                 msg.value = '';
+            });
+
+            $("#file-send").on("click", function (event) {
+                var form = document.querySelector(".modal form");
+                var formData = new FormData(form);
+
+                var inputFile = $("input[name='file']");
+                var files = inputFile[0].files;
+
+                $.ajax({
+                    url: form.action,
+                    type: "POST",
+                    enctype: 'multipart/form-data',
+                    data: files,
+                    processData: false,
+                    contentType: false,
+                    success: function (data) {
+                        console.log("파일 전송 성공:", data);
+                        document.getElementById("send-msg").value = "";
+                    },
+                    error: function (error) {
+                        console.error("파일 전송 실패:", error);
+                    }
+                });
             });
         });
     </script>

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -17,7 +17,10 @@
             </div>
         </div>
         <div class="navbar-center">
-            <a class="font-black" th:text="|${otherMember.getUsername()} 님과의 채팅|"></a>
+            <span th:if="${otherMember.getUsername().length() > 15}"
+                  class="font-black" th:text="|${otherMember.getUsername().substring(0, 15)}... 님과의 채팅|"></span>
+            <span th:if="${otherMember.getUsername().length() <= 15}"
+                  class="font-black" th:text="|${otherMember.getUsername()} 님과의 채팅|"></span>
         </div>
         <div class="navbar-end">
             <label for="my_modal_7" class="btn btn-ghost btn-circle">
@@ -28,7 +31,7 @@
                 <div class="modal-box">
                     <a th:if="${room.tradeStatus.status.msg.equals('거래 전')}" class="btn btn-ghost block pt-4"
                        th:href="@{/trade/start/{id}(id=${room.tradeStatus.id})}">거래 시작</a>
-                    <a th:if="${room.tradeStatus.status.msg.equals('거래 중')}" class="btn btn-ghost block pt-4"
+                    <a th:if="${!room.tradeStatus.status.msg.equals('거래 전')}" class="btn btn-ghost block pt-4"
                        th:href="@{/trade/complete/{id}(id=${room.tradeStatus.id})}">거래 완료</a>
                     <hr>
                     <a th:href="@{/chat/exit/{id}(id=${room.id})}" class="btn btn-ghost block pt-4">채팅방 나가기</a>
@@ -39,35 +42,44 @@
     </div>
 </header>
 
-<main layout:fragment="main" class="flex-grow flex items-center justify-center w-screen h-[750px] p-8">
+<main layout:fragment="main" class="flex-grow flex items-center justify-center w-screen h-[740px] p-8">
     <div id="chat-area" class="flex flex-col w-[650px] h-full">
-        <div id="messages" class="flex text-center w-full justify-end" th:each="message : ${chatMessages}">
-            <div class="chat chat-start" th:if="${!@rq.getMember().getNickname().equals(message.writer)}">
-                <div class="chat-image avatar">
-                    <div class="w-10 rounded-full bg-pink-400"></div>
+        <div id="msg-area" class="overflow-y-auto h-[600px]">
+            <div id="messages"
+                 th:class="${@rq.getMember().getNickname().equals(message.writer)} ? 'flex w-full justify-end' : 'flex w-full justify-start'"
+                 th:each="message : ${chatMessages}">
+                <div class="chat chat-start flex" th:if="${!@rq.getMember().getNickname().equals(message.writer)}">
+                    <div class="chat-image avatar">
+                        <div class="w-10 rounded-full bg-pink-400"></div>
+                    </div>
+                    <div class="chat-bubble" th:text="${message.message}"></div>
+                    <div class="chat-header mt-6">
+                        <time class="text-xs opacity-50"
+                              th:text="${#temporals.format(message.createdAt, 'HH:mm')}"></time>
+                    </div>
                 </div>
-                <div class="chat-header">
-                    <time class="text-xs opacity-50" th:text="${#temporals.format(message.createdAt, 'HH:mm')}"></time>
-                </div>
-                <div class="chat-bubble" th:text="${message.message}"></div>
-            </div>
-            <div class="chat chat-end flex justify-end" th:if="${@rq.getMember().getNickname().equals(message.writer)}">
-                <div class="chat-header">
-                    <time class="text-xs opacity-50" th:text="${#temporals.format(message.createdAt, 'HH:mm')}"></time>
-                </div>
-                <div class="chat-bubble" th:text="${message.message}"></div>
-                <div class="chat-image avatar">
-                    <div class="w-10 rounded-full bg-pink-400"></div>
+                <div class="chat chat-end flex" th:if="${@rq.getMember().getNickname().equals(message.writer)}">
+                    <div class="chat-header">
+                        <time class="text-xs opacity-50"
+                              th:text="${#temporals.format(message.createdAt, 'HH:mm')}"></time>
+                    </div>
+                    <div class="chat-bubble" th:text="${message.message}"></div>
+                    <div class="chat-image avatar">
+                        <div class="w-10 rounded-full bg-pink-400"></div>
+                    </div>
                 </div>
             </div>
         </div>
         <div id="input-area" class="flex order-1 justify-center mt-auto mb-12">
             <input id="send-msg" type="text" class="input input-bordered w-full max-w-sm"/>
             <button id="send-button" class="btn btn-outline"><i class="fa-regular fa-paper-plane"></i></button>
-            <button class="btn" onclick="my_modal_1.showModal()"><i class="fa-solid fa-paperclip"></i></button>
+            <button class="btn btn-outline" onclick="my_modal_1.showModal()"><i class="fa-solid fa-paperclip"></i>
+            </button>
             <dialog id="my_modal_1" class="modal">
-                <form method="dialog" class="modal-box" enctype="multipart/form-data" th:action="@{/chat/file(roomId=${room.id})}">
-                    <input type="file" class="file-input file-input-bordered file-input-sm w-full max-w-sm" name="file" />
+                <form method="dialog" class="modal-box" enctype="multipart/form-data"
+                      th:action="@{/chat/file(roomId=${room.id})}">
+                    <input type="file" class="file-input file-input-bordered file-input-sm w-full max-w-sm"
+                           name="file"/>
                     <div class="modal-action">
                         <button id="file-send" type="submit" class="btn">보내기</button>
                         <button class="btn">닫기</button>
@@ -81,6 +93,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
     <script th:inline="javascript">
         $(document).ready(function () {
+
+            function scrollToBottom() {
+                var msgArea = document.getElementById("msg-area");
+                msgArea.scrollTop = msgArea.scrollHeight;
+            }
+
+            scrollToBottom();
+
             var sockJs = new SockJS("/ws/chat");
             var stomp = Stomp.over(sockJs);
 
@@ -93,15 +113,27 @@
                     var writer = content.writer;
 
                     var msg = document.createElement("div");
-                    msg.className = writer === username ? "chat chat-end" : "chat chat-start";
-                    msg.innerHTML = "<div class='chat-image avatar'><div class='w-10 rounded-full bg-pink-400'></div></div>" +
+                    var currentTime = new Date().toLocaleTimeString([], {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false
+                    });
+
+                    msg.className = writer === username ? "items-start chat chat-end flex flex-row justify-end" :
+                        "items-start chat chat-start flex flex-row justify-start";
+                    msg.innerHTML = writer === username ?
                         "<div class='chat-header'>" +
-                        "<time class='text-xs opacity-50' th:utext='${#temporals.format(message.getCreatedAt(), 'HH:mm')}'></time>" +
-                        "</div>" +
-                        "<div class='chat-bubble'>" + content.message + "</div>";
+                        "<time class='text-xs opacity-50'>" + currentTime + "</time>" + "</div>" +
+                        "<div class='chat-bubble'>" + content.message + "</div>" +
+                        "<div class='chat-image avatar'><div class='w-10 rounded-full bg-pink-400'></div></div>" :
+                        "<div class='chat-image avatar'><div class='w-10 rounded-full bg-pink-400'></div></div>" +
+                        "<div class='chat-header'>" +
+                        "</div>" + "<div class='chat-bubble'>" + content.message + "</div>" +
+                        "<time class='text-xs opacity-50'>" + currentTime + "</time>";
+
 
                     $("#chat-area").append(msg);
-                    $("#chat-area").scrollTop($("#chat-area")[0].scrollHeight);
+                    scrollToBottom();
                 });
 
                 if (msg.value != null) {
@@ -129,6 +161,7 @@
                     writer: username
                 }));
                 msg.value = '';
+                scrollToBottom();
             });
 
             $("#file-send").on("click", function (event) {

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -46,7 +46,8 @@
     <div id="chat-area" class="flex flex-col w-[650px] h-full">
         <div id="msg-area" class="overflow-y-auto h-[600px]">
             <div id="messages"
-                 th:class="${@rq.getMember().getNickname().equals(message.writer)} ? 'flex w-full justify-end' : 'flex w-full justify-start'"
+                 th:class="${@rq.getMember().getNickname().equals(message.writer)} ?
+                 'flex w-full justify-end' : 'flex w-full justify-start'"
                  th:each="message : ${chatMessages}">
                 <div class="chat chat-start flex" th:if="${!@rq.getMember().getNickname().equals(message.writer)}">
                     <div class="chat-image avatar">
@@ -57,6 +58,8 @@
                         <time class="text-xs opacity-50"
                               th:text="${#temporals.format(message.createdAt, 'HH:mm')}"></time>
                     </div>
+                    <a th:if="${message.isFileMessage()}" target="_blank" class="ml-2"
+                       th:href="@{/download/{messageId}(messageId=${message.getId()})}">다운로드</a>
                 </div>
                 <div class="chat chat-end flex" th:if="${@rq.getMember().getNickname().equals(message.writer)}">
                     <div class="chat-header">
@@ -67,6 +70,8 @@
                     <div class="chat-image avatar">
                         <div class="w-10 rounded-full bg-pink-400"></div>
                     </div>
+                    <a th:if="${message.isFileMessage()}" target="_blank" class="ml-2"
+                       th:href="@{/download/{messageId}(messageId=${message.getId()})}">다운로드</a>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/chat/room.html
+++ b/src/main/resources/templates/chat/room.html
@@ -78,6 +78,7 @@
             <dialog id="my_modal_1" class="modal">
                 <form method="dialog" class="modal-box" enctype="multipart/form-data"
                       th:action="@{/chat/file(roomId=${room.id})}">
+                    <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/>
                     <input type="file" class="file-input file-input-bordered file-input-sm w-full max-w-sm"
                            name="file"/>
                     <div class="modal-action">
@@ -168,14 +169,14 @@
                 var form = document.querySelector(".modal form");
                 var formData = new FormData(form);
 
-                var inputFile = $("input[name='file']");
-                var files = inputFile[0].files;
+                var csrfToken = $("input[name='_csrf']").val();
+                formData.append("_csrf", csrfToken);
 
                 $.ajax({
                     url: form.action,
                     type: "POST",
                     enctype: 'multipart/form-data',
-                    data: files,
+                    data: formData,
                     processData: false,
                     contentType: false,
                     success: function (data) {


### PR DESCRIPTION
채팅방과 채팅 목록 페이지를 모바일 화면에 맞게 수정하고, 깨져 보이는 부분도 수정했습니다.
상대방의 유저네임이 길면 'User1234... 님' 이런 형식으로 줄여서 보일 수 있게 구현했습니다.
채팅방에 입장하면 가장 아래에 있는 최신 메시지가 보이도록 스크롤이 아래에 있는 상태로 새로고침되는 방식도 구현했습니다.
정작 파일 송신/수신 구현은 아직 제자리네요... 백엔드 로직은 구현했는데 html에서 계속 파일 전송 실패가 떠서 로직이 정상적으로 실행되는지 테스트를 못 하고 있는 상태입니다. 자바스크립트나 ajax, 혹은 파일 업로드에 대해 잘 아시는 분의 도움이 필요합니다,, ㅠㅠ

---> 파일 전송 테스트 성공했습니다! 이제 다운로드 받는 로직만 제대로 구현하면 될 것 같습니다.