### PR TITLE
Fix/chat: 몽고 디비 초기화 로직을 분리

### DIFF
--- a/src/main/java/com/ant/hurry/base/initData/DataLoader.java
+++ b/src/main/java/com/ant/hurry/base/initData/DataLoader.java
@@ -8,8 +8,6 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class DataLoader implements CommandLineRunner {
@@ -28,19 +26,6 @@ public class DataLoader implements CommandLineRunner {
             Role memberRole = new Role(RoleType.ROLE_MEMBER);
             roleRepository.save(memberRole);
         }
-        initializeSchema();
     }
 
-    private void initializeSchema() {
-        List<String> collections = List.of(
-                "chat_file", "chat_message", "chat_room", "deleted_room", "fs.chunks", "fs.files", "latest_message"
-        );
-
-        for(String collection : collections) {
-            if(mongoTemplate.collectionExists(collection)) {
-                mongoTemplate.dropCollection(collection);
-                mongoTemplate.createCollection(collection);
-            }
-        }
-    }
 }

--- a/src/main/java/com/ant/hurry/base/initData/InitializeMongoDb.java
+++ b/src/main/java/com/ant/hurry/base/initData/InitializeMongoDb.java
@@ -1,0 +1,29 @@
+package com.ant.hurry.base.initData;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class InitializeMongoDb implements CommandLineRunner {
+
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public void run(String... args) {
+        List<String> collections = List.of(
+                "chat_file", "chat_message", "chat_room", "deleted_room", "fs.chunks", "fs.files", "latest_message"
+        );
+
+        for (String collection : collections) {
+            if (mongoTemplate.collectionExists(collection)) {
+                mongoTemplate.dropCollection(collection);
+                mongoTemplate.createCollection(collection);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ant/hurry/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/ant/hurry/chat/controller/ChatRoomController.java
@@ -20,10 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @RequiredArgsConstructor
 @Controller
@@ -76,12 +73,14 @@ public class ChatRoomController {
     @Operation(summary = "채팅 목록 조회", description = "유저가 속한 채팅 목록을 조회합니다.")
     @GetMapping("/myRooms")
     public String showMyRooms(Model model) {
-        List<ChatRoom> chatRooms = chatRoomService.findByMember(rq.getMember()).getData();
+        List<ChatRoom> chatRooms = chatRoomService.findByMember(rq.getMember()).getData().stream()
+                .sorted(Comparator.comparing(ChatRoom::getCreatedAt)).toList();
         Map<ChatRoom, LatestMessage> map = new HashMap<>();
 
         for (ChatRoom chatRoom : chatRooms) {
-            LatestMessage latestmessage = latestMessageService.findByChatRoomId(chatRoom.getId()).getData().getMessage() == null ?
-                    null : latestMessageService.findByChatRoomId(chatRoom.getId()).getData();
+            LatestMessage latestmessage =
+                    latestMessageService.findByChatRoomId(chatRoom.getId()).getData().getMessage() == null ?
+                            null : latestMessageService.findByChatRoomId(chatRoom.getId()).getData();
             if (latestmessage != null) {
                 map.put(chatRoom, latestmessage);
             }


### PR DESCRIPTION
몽고 디비 초기화 로직을 분리하고 채팅 목록을 불러올 때 채팅방 생성 날짜의 내림차순으로 정렬되어 불러오도록 수정했습니다. 최신 메시지 순으로 정렬하고 싶었지만 수정할 로직이 너무 많을 거 같아 일단은... 이렇게 했습니다 ㅠ